### PR TITLE
Updating nginx.conf for CSP policies

### DIFF
--- a/Starteryou/frontend/nginx.conf
+++ b/Starteryou/frontend/nginx.conf
@@ -92,7 +92,12 @@ http {
         add_header X-Content-Type-Options nosniff;
         add_header X-XSS-Protection "1; mode=block";
         add_header Referrer-Policy "strict-origin-when-cross-origin";
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:";
+        add_header Content-Security-Policy "default-src 'self'; 
+                    script-src 'self' 'unsafe-inline' 'unsafe-eval'; 
+                    style-src 'self' 'unsafe-inline'; 
+                    img-src 'self' data: blob:; 
+                    font-src 'self' data:; 
+                    connect-src 'self' https://starteryou.com;";
 
         # Error Pages
         error_page 404 /404.html;


### PR DESCRIPTION
### **PR Description: Fix Content Security Policy (CSP) to Allow API Requests**  

#### **Summary**  
This PR updates the **Content Security Policy (CSP)** in the Nginx configuration to explicitly allow API requests to `https://starteryou.com/api/`. Previously, the absence of a `connect-src` directive caused requests to be blocked by the default CSP settings.  

#### **Changes**  
- Added `connect-src 'self' https://starteryou.com;` to the CSP directive in `nginx.conf`.  
- Ensured the frontend can successfully communicate with the backend API.  
- Restarted Nginx to apply changes.  

#### **Testing**  
- Verified API requests are no longer blocked in the browser console.  
- Checked Developer Tools to confirm CSP violations are resolved.  
- Successfully fetched API data using `fetch()` in the browser console.  

#### **Impact**  
This fix ensures smooth API communication between the frontend and backend, improving site functionality.  