### PR TITLE
Enabling Trust Proxy in Express.js for Reverse Proxy Setup

### DIFF
--- a/Starteryou/frontend/nginx.conf
+++ b/Starteryou/frontend/nginx.conf
@@ -65,7 +65,7 @@ http {
         }
 
         location /api/ {
-            proxy_pass http://starteryou-backend:3000;
+            proxy_pass https://starteryou.com:3000;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -88,16 +88,16 @@ http {
         }
 
         # Security Headers
-        add_header X-Frame-Options DENY;
+        add_header X-Frame-Options "SAMEORIGIN";
         add_header X-Content-Type-Options nosniff;
         add_header X-XSS-Protection "1; mode=block";
         add_header Referrer-Policy "strict-origin-when-cross-origin";
         add_header Content-Security-Policy "default-src 'self'; 
-                    script-src 'self' 'unsafe-inline' 'unsafe-eval'; 
-                    style-src 'self' 'unsafe-inline'; 
-                    img-src 'self' data: blob:; 
-                    font-src 'self' data:; 
-                    connect-src 'self' https://starteryou.com;";
+            script-src 'self' 'unsafe-inline' 'unsafe-eval'; 
+            style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; 
+            img-src 'self' data: blob: https://via.placeholder.com; 
+            font-src 'self' data: https://fonts.gstatic.com; 
+            connect-src 'self' https://starteryou.com;";
 
         # Error Pages
         error_page 404 /404.html;

--- a/Starteryou/frontend/src/context/UserContext.jsx
+++ b/Starteryou/frontend/src/context/UserContext.jsx
@@ -14,8 +14,11 @@ const UserContext = createContext();
  * @returns {JSX.Element} The UserProvider component.
  */
 export const UserProvider = ({ children }) => {
-  const [user, setUser] = useState(null);
-
+  const [user, setUser] = useState(() => {
+    const savedUser = localStorage.getItem("loginUser");
+    const savedToken = localStorage.getItem("token");
+    return savedUser && savedToken ? { authenticatedUser: JSON.parse(savedUser), token: savedToken } : null;
+  });
   /**
    * Logs in the user by storing authentication data.
    *


### PR DESCRIPTION
Configuring Express.js to trust proxy headers is essential when running behind a reverse proxy like Nginx. This setup ensures that Express correctly identifies client IP addresses and protocols (HTTP/HTTPS) based on headers set by the proxy.